### PR TITLE
🛠 Carthage で必要なライブラリをインストール

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
-Carthage/Build/
+Carthage/
 
 # Accio dependency management
 Dependencies/

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,3 @@
+github "ReactiveX/RxSwift" ~> 5.0
+github "Alamofire/Alamofire" ~> 5.2
+github "onevcat/Kingfisher" ~> 5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,3 @@
+github "Alamofire/Alamofire" "5.2.2"
+github "ReactiveX/RxSwift" "5.1.1"
+github "onevcat/Kingfisher" "5.15.4"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@
 2. GitHub API（`search/repositories`）でリポジトリーを検索し、結果一覧を概要（リポジトリ名）で表示
 3. 特定の結果を選択したら、該当リポジトリの詳細（リポジトリ名、オーナーアイコン、プロジェクト言語、Star 数、Watcher 数、Fork 数、Issue 数）を表示
 
+## 事前準備
+
+### Carthage
+
+本アプリでは [Carthage](https://github.com/Carthage/Carthage) を使用してサードパーティー製ライブラリを管理しています。  
+インストールした上でプロジェクトがあるフォルダで以下のコマンドを実行し、ライブラリのインストールを行ってください。
+
+```Shell
+carthage bootstrap --platform iOS
+```
+
+**⚠️ Xcode12 の場合**
+
+2020/9/25 現在、Xcode12 で Carthage のビルドを行うと失敗する場合があります。  
+よってワークアラウンドとしてプロジェクトがあるフォルダで以下のコマンドを実行してビルドを行ってください。
+
+```Shell
+sh ./carthage-build.sh bootstrap --platform iOS
+```
+
 ## 課題取り組み方法
 
 Issues を確認した上、本プロジェクトを [**Duplicate** してください](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/duplicating-a-repository)（Fork しないようにしてください。必要ならプライベートリポジトリーにしても大丈夫です）。今後のコミットは全てご自身のリポジトリーで行ってください。

--- a/carthage-build.sh
+++ b/carthage-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# carthage-build.sh
+# Usage example: ./carthage-build.sh --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+# Xcode 12 Beta 3:
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8169g = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 beta 4
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8179i = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 beta 5
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8189h = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 beta 6
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8189n = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 GM (12A7208)
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7208 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+# Xcode 12 GM (12A7209)
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7209 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		712D67BC251D97F9000DC884 /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 712D67B7251D97F8000DC884 /* Kingfisher.framework */; };
+		712D67BE251D97F9000DC884 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 712D67B8251D97F9000DC884 /* RxSwift.framework */; };
+		712D67C0251D97F9000DC884 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 712D67B9251D97F9000DC884 /* Alamofire.framework */; };
+		712D67C2251D97F9000DC884 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 712D67BA251D97F9000DC884 /* RxRelay.framework */; };
+		712D67C4251D97F9000DC884 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 712D67BB251D97F9000DC884 /* RxCocoa.framework */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -36,6 +41,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		712D67B7251D97F8000DC884 /* Kingfisher.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kingfisher.framework; path = Carthage/Build/iOS/Kingfisher.framework; sourceTree = "<group>"; };
+		712D67B8251D97F9000DC884 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
+		712D67B9251D97F9000DC884 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
+		712D67BA251D97F9000DC884 /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
+		712D67BB251D97F9000DC884 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -58,6 +68,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				712D67C2251D97F9000DC884 /* RxRelay.framework in Frameworks */,
+				712D67BE251D97F9000DC884 /* RxSwift.framework in Frameworks */,
+				712D67C0251D97F9000DC884 /* Alamofire.framework in Frameworks */,
+				712D67C4251D97F9000DC884 /* RxCocoa.framework in Frameworks */,
+				712D67BC251D97F9000DC884 /* Kingfisher.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +93,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		712D67B6251D97F8000DC884 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				712D67B9251D97F9000DC884 /* Alamofire.framework */,
+				712D67B7251D97F8000DC884 /* Kingfisher.framework */,
+				712D67BB251D97F9000DC884 /* RxCocoa.framework */,
+				712D67BA251D97F9000DC884 /* RxRelay.framework */,
+				712D67B8251D97F9000DC884 /* RxSwift.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BFD945D2244DC5E80012785A = {
 			isa = PBXGroup;
 			children = (
@@ -85,6 +112,7 @@
 				BFD945F4244DC5EB0012785A /* iOSEngineerCodeCheckTests */,
 				BFD945FF244DC5EB0012785A /* iOSEngineerCodeCheckUITests */,
 				BFD945DC244DC5E80012785A /* Products */,
+				712D67B6251D97F8000DC884 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -141,6 +169,7 @@
 				BFD945D7244DC5E80012785A /* Sources */,
 				BFD945D8244DC5E80012785A /* Frameworks */,
 				BFD945D9244DC5E80012785A /* Resources */,
+				712D67CC251D9804000DC884 /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -256,6 +285,32 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		712D67CC251D9804000DC884 /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Kingfisher.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/RxCocoa.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/RxRelay.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/RxSwift.framework",
+			);
+			name = Carthage;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		BFD945D7244DC5E80012785A /* Sources */ = {
@@ -440,6 +495,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = iOSEngineerCodeCheck/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -458,6 +517,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = iOSEngineerCodeCheck/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## 📝 詳細

以下のライブラリをインストール

- RxSwift
- Alamofire
- Kingfisher

### ⚠️ Xcode12 での Carthage ビルドのワークアラウンド

現在 Xcode12 で Carthage の `update` もしくは `bootstrap` を行うと失敗する場合がある。
よって以下の記事を参考に `carthage-build.sh` スクリプトを配置して以下のコマンドでビルドを行う。

```Shell
sh ./carthage-build.sh bootstrap --platform iOS --cache-builds
```

- [iOS14 対応で気をつけるべきこと](https://zenn.dev/tattn/articles/40d1e53cc63d381a3ac5#carthage%E3%81%A7%E3%81%AE%E3%83%93%E3%83%AB%E3%83%89%E3%82%A8%E3%83%A9%E3%83%BC)