### PR TITLE
🆕 APIClient クラスを追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		712D682A251DA3CB000DC884 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6829251DA3CB000DC884 /* ResponseTests.swift */; };
 		712D683A251DAABD000DC884 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6839251DAABC000DC884 /* APIRequest.swift */; };
 		712D6842251DC63E000DC884 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6841251DC63E000DC884 /* APIClient.swift */; };
+		712D6846251DD1CE000DC884 /* SearchRepositoriesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6845251DD1CE000DC884 /* SearchRepositoriesRequest.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -81,6 +82,7 @@
 		712D6829251DA3CB000DC884 /* ResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 		712D6839251DAABC000DC884 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		712D6841251DC63E000DC884 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		712D6845251DD1CE000DC884 /* SearchRepositoriesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesRequest.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				712D6839251DAABC000DC884 /* APIRequest.swift */,
+				712D6845251DD1CE000DC884 /* SearchRepositoriesRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -437,6 +440,7 @@
 				712D67FE251D9D26000DC884 /* RepositoryOwner.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				712D6842251DC63E000DC884 /* APIClient.swift in Sources */,
+				712D6846251DD1CE000DC884 /* SearchRepositoriesRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		712D681A251DA297000DC884 /* SearchRepositoriesResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 712D6819251DA297000DC884 /* SearchRepositoriesResponse.json */; };
 		712D6824251DA334000DC884 /* SearchRepositoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6823251DA334000DC884 /* SearchRepositoriesResponse.swift */; };
 		712D682A251DA3CB000DC884 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6829251DA3CB000DC884 /* ResponseTests.swift */; };
+		712D683A251DAABD000DC884 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6839251DAABC000DC884 /* APIRequest.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -77,6 +78,7 @@
 		712D6819251DA297000DC884 /* SearchRepositoriesResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SearchRepositoriesResponse.json; sourceTree = "<group>"; };
 		712D6823251DA334000DC884 /* SearchRepositoriesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesResponse.swift; sourceTree = "<group>"; };
 		712D6829251DA3CB000DC884 /* ResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
+		712D6839251DAABC000DC884 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 		712D67F3251D9CD4000DC884 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				712D6838251DAA67000DC884 /* Request */,
 				712D67F4251D9CDD000DC884 /* Response */,
 			);
 			path = Network;
@@ -196,6 +199,14 @@
 				712D6829251DA3CB000DC884 /* ResponseTests.swift */,
 			);
 			path = Response;
+			sourceTree = "<group>";
+		};
+		712D6838251DAA67000DC884 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				712D6839251DAABC000DC884 /* APIRequest.swift */,
+			);
+			path = Request;
 			sourceTree = "<group>";
 		};
 		BFD945D2244DC5E80012785A = {
@@ -415,6 +426,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFD945E3244DC5E80012785A /* SearchRepositoriesViewController.swift in Sources */,
+				712D683A251DAABD000DC884 /* APIRequest.swift in Sources */,
 				712D6824251DA334000DC884 /* SearchRepositoriesResponse.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		712D6824251DA334000DC884 /* SearchRepositoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6823251DA334000DC884 /* SearchRepositoriesResponse.swift */; };
 		712D682A251DA3CB000DC884 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6829251DA3CB000DC884 /* ResponseTests.swift */; };
 		712D683A251DAABD000DC884 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6839251DAABC000DC884 /* APIRequest.swift */; };
+		712D6842251DC63E000DC884 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6841251DC63E000DC884 /* APIClient.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -79,6 +80,7 @@
 		712D6823251DA334000DC884 /* SearchRepositoriesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesResponse.swift; sourceTree = "<group>"; };
 		712D6829251DA3CB000DC884 /* ResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 		712D6839251DAABC000DC884 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
+		712D6841251DC63E000DC884 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 		712D67F3251D9CD4000DC884 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				712D6841251DC63E000DC884 /* APIClient.swift */,
 				712D6838251DAA67000DC884 /* Request */,
 				712D67F4251D9CDD000DC884 /* Response */,
 			);
@@ -433,6 +436,7 @@
 				712D67F6251D9CEE000DC884 /* Repository.swift in Sources */,
 				712D67FE251D9D26000DC884 /* RepositoryOwner.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
+				712D6842251DC63E000DC884 /* APIClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck/Network/APIClient.swift
+++ b/iOSEngineerCodeCheck/Network/APIClient.swift
@@ -1,0 +1,57 @@
+//
+//  APIClient.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/25.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import Alamofire
+import RxSwift
+
+protocol APIClientProtocol: AnyObject {
+    func call<T: APIRequest>(with request: T) -> Single<T.Response>
+}
+
+final class APIClient: APIClientProtocol {
+    
+    // MARK: Singleton
+    
+    static let shared: APIClient = .init()
+    
+    // MARK: Initializer
+    
+    private init() {}
+    
+    // MARK: Call
+    
+    func call<T: APIRequest>(with request: T) -> Single<T.Response> {
+        return Single.create { observer in
+            let url     = request.endpoint + request.path
+            let request = AF.request(url,
+                                     method: request.method,
+                                     parameters: request.parameters,
+                                     encoding: request.encoding,
+                                     headers: request.headers)
+                .responseJSON { response in
+                    switch response.result {
+                    case .success:
+                        do {
+                            guard let data = response.data else {
+                                return
+                            }
+                            let object = try JSONDecoder().decode(T.Response.self, from: data)
+                            observer(.success(object))
+                        } catch {
+                            observer(.error(error))
+                        }
+                    case .failure(let error):
+                        observer(.error(error))
+                    }
+                }
+            return Disposables.create {
+                request.cancel()
+            }
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/Network/Request/APIRequest.swift
+++ b/iOSEngineerCodeCheck/Network/Request/APIRequest.swift
@@ -1,0 +1,39 @@
+//
+//  APIRequest.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/25.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import Alamofire
+
+protocol APIRequest {
+    associatedtype Response: Decodable
+    
+    var endpoint: String { get }
+    var path: String { get }
+    var method: Alamofire.HTTPMethod { get }
+    var encoding: Alamofire.ParameterEncoding { get }
+    var parameters: Alamofire.Parameters? { get }
+    var headers: Alamofire.HTTPHeaders? { get }
+}
+
+extension APIRequest {
+    
+    var endpoint: String {
+        return "https://api.github.com"
+    }
+    
+    var encoding: Alamofire.ParameterEncoding {
+        return JSONEncoding.default
+    }
+    
+    var parameters: Alamofire.Parameters? {
+        return nil
+    }
+    
+    var headers: Alamofire.HTTPHeaders? {
+        return nil
+    }
+}

--- a/iOSEngineerCodeCheck/Network/Request/SearchRepositoriesRequest.swift
+++ b/iOSEngineerCodeCheck/Network/Request/SearchRepositoriesRequest.swift
@@ -1,0 +1,33 @@
+//
+//  SearchRepositoriesRequest.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/25.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import Alamofire
+
+struct SearchRepositoriesRequest: APIRequest {
+    typealias Response = SearchRepositoriesResponse
+    
+    let keyword: String
+    
+    var path: String {
+        return "/search/repositories"
+    }
+    
+    var method: HTTPMethod {
+        return .get
+    }
+    
+    var encoding: ParameterEncoding {
+        return URLEncoding.queryString
+    }
+    
+    var parameters: Parameters? {
+        return [
+            "q": keyword
+        ]
+    }
+}


### PR DESCRIPTION
## 📝 詳細

- API との通信時のリクエストを表す `APIRequest` プロトコルを追加
- GitHub の API `/search/repositories` へのリクエストを追加
- API との通信を行う `APIClient` クラスを追加