### PR TITLE
♻️ リポジトリ検索画面のセルを更新

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		712D6854251DD4E2000DC884 /* SearchRepositoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6853251DD4E2000DC884 /* SearchRepositoriesModel.swift */; };
 		712D6889251E035B000DC884 /* GitHubAPISearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6888251E035B000DC884 /* GitHubAPISearchRepository.swift */; };
 		712DAF442520A96F00889011 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712DAF432520A96F00889011 /* ImageView.swift */; };
+		712DAF4A2520AAA200889011 /* SearchRepositoriesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712DAF482520AAA200889011 /* SearchRepositoriesCell.swift */; };
+		712DAF4B2520AAA200889011 /* SearchRepositoriesCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 712DAF492520AAA200889011 /* SearchRepositoriesCell.xib */; };
 		71402009251E07F2007CE443 /* StubGitHubAPISearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71402008251E07F2007CE443 /* StubGitHubAPISearchRepository.swift */; };
 		71402012251E08CF007CE443 /* SearchRepositoriesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71402011251E08CF007CE443 /* SearchRepositoriesModelTests.swift */; };
 		71402019251E31AF007CE443 /* StubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71402018251E31AF007CE443 /* StubError.swift */; };
@@ -99,6 +101,8 @@
 		712D6853251DD4E2000DC884 /* SearchRepositoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesModel.swift; sourceTree = "<group>"; };
 		712D6888251E035B000DC884 /* GitHubAPISearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPISearchRepository.swift; sourceTree = "<group>"; };
 		712DAF432520A96F00889011 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		712DAF482520AAA200889011 /* SearchRepositoriesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesCell.swift; sourceTree = "<group>"; };
+		712DAF492520AAA200889011 /* SearchRepositoriesCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchRepositoriesCell.xib; sourceTree = "<group>"; };
 		71402008251E07F2007CE443 /* StubGitHubAPISearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubGitHubAPISearchRepository.swift; sourceTree = "<group>"; };
 		71402011251E08CF007CE443 /* SearchRepositoriesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesModelTests.swift; sourceTree = "<group>"; };
 		71402018251E31AF007CE443 /* StubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubError.swift; sourceTree = "<group>"; };
@@ -258,6 +262,15 @@
 			path = Repository;
 			sourceTree = "<group>";
 		};
+		712DAF472520AA7D00889011 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				712DAF482520AAA200889011 /* SearchRepositoriesCell.swift */,
+				712DAF492520AAA200889011 /* SearchRepositoriesCell.xib */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		71402007251E07DB007CE443 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
@@ -323,6 +336,7 @@
 			children = (
 				BFD945E2244DC5E80012785A /* SearchRepositoriesViewController.swift */,
 				7140204E251E5198007CE443 /* SearchRepositoriesViewController.storyboard */,
+				712DAF472520AA7D00889011 /* Cell */,
 			);
 			path = SearchRepositories;
 			sourceTree = "<group>";
@@ -522,6 +536,7 @@
 			files = (
 				BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */,
 				BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */,
+				712DAF4B2520AAA200889011 /* SearchRepositoriesCell.xib in Resources */,
 				71402055251ED72C007CE443 /* RepositoryDetailViewController.storyboard in Resources */,
 				7140204F251E5198007CE443 /* SearchRepositoriesViewController.storyboard in Resources */,
 			);
@@ -584,6 +599,7 @@
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				71402049251E5035007CE443 /* DisposableViewController.swift in Sources */,
 				712DAF442520A96F00889011 /* ImageView.swift in Sources */,
+				712DAF4A2520AAA200889011 /* SearchRepositoriesCell.swift in Sources */,
 				712D67F6251D9CEE000DC884 /* Repository.swift in Sources */,
 				71402024251E4381007CE443 /* SearchRepositoriesViewModel.swift in Sources */,
 				712D67FE251D9D26000DC884 /* RepositoryOwner.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		712D6846251DD1CE000DC884 /* SearchRepositoriesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6845251DD1CE000DC884 /* SearchRepositoriesRequest.swift */; };
 		712D6854251DD4E2000DC884 /* SearchRepositoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6853251DD4E2000DC884 /* SearchRepositoriesModel.swift */; };
 		712D6889251E035B000DC884 /* GitHubAPISearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D6888251E035B000DC884 /* GitHubAPISearchRepository.swift */; };
+		712DAF442520A96F00889011 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712DAF432520A96F00889011 /* ImageView.swift */; };
 		71402009251E07F2007CE443 /* StubGitHubAPISearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71402008251E07F2007CE443 /* StubGitHubAPISearchRepository.swift */; };
 		71402012251E08CF007CE443 /* SearchRepositoriesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71402011251E08CF007CE443 /* SearchRepositoriesModelTests.swift */; };
 		71402019251E31AF007CE443 /* StubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71402018251E31AF007CE443 /* StubError.swift */; };
@@ -97,6 +98,7 @@
 		712D6845251DD1CE000DC884 /* SearchRepositoriesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesRequest.swift; sourceTree = "<group>"; };
 		712D6853251DD4E2000DC884 /* SearchRepositoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesModel.swift; sourceTree = "<group>"; };
 		712D6888251E035B000DC884 /* GitHubAPISearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPISearchRepository.swift; sourceTree = "<group>"; };
+		712DAF432520A96F00889011 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		71402008251E07F2007CE443 /* StubGitHubAPISearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubGitHubAPISearchRepository.swift; sourceTree = "<group>"; };
 		71402011251E08CF007CE443 /* SearchRepositoriesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesModelTests.swift; sourceTree = "<group>"; };
 		71402018251E31AF007CE443 /* StubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubError.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 			isa = PBXGroup;
 			children = (
 				71402048251E5035007CE443 /* DisposableViewController.swift */,
+				712DAF432520A96F00889011 /* ImageView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -580,6 +583,7 @@
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				71402049251E5035007CE443 /* DisposableViewController.swift in Sources */,
+				712DAF442520A96F00889011 /* ImageView.swift in Sources */,
 				712D67F6251D9CEE000DC884 /* Repository.swift in Sources */,
 				71402024251E4381007CE443 /* SearchRepositoriesViewModel.swift in Sources */,
 				712D67FE251D9D26000DC884 /* RepositoryOwner.swift in Sources */,

--- a/iOSEngineerCodeCheck/Common/View/ImageView.swift
+++ b/iOSEngineerCodeCheck/Common/View/ImageView.swift
@@ -1,0 +1,48 @@
+//
+//  ImageView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/27.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+class ImageView: UIImageView {
+
+    // MARK: IBInspectable
+    
+    @IBInspectable var cornerRadius: CGFloat = 0
+    @IBInspectable var borderWidth: CGFloat = 0
+    @IBInspectable var borderColor: UIColor = .clear
+
+    // MARK: Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configure()
+    }
+
+    override func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        configure()
+    }
+
+    private func configure() {
+        isExclusiveTouch = true
+
+        backgroundColor = .clear
+        layer.cornerRadius = cornerRadius
+        layer.borderWidth = borderWidth
+        layer.borderColor = borderColor.cgColor
+    }
+}

--- a/iOSEngineerCodeCheck/Network/Response/Repository.swift
+++ b/iOSEngineerCodeCheck/Network/Response/Repository.swift
@@ -9,17 +9,23 @@
 import Foundation
 
 struct Repository: Decodable {
+    let name: String
     let fullName: String
+    let desc: String?
     let owner: RepositoryOwner
+    let homepage: String?
     let stargazersCount: Int
     let watchersCount: Int
-    let language: String
+    let language: String?
     let forksCount: Int
     let openIssueCount: Int
     
     private enum CodingKeys: String, CodingKey {
+        case name
         case fullName           = "full_name"
+        case desc               = "description"
         case owner
+        case homepage
         case stargazersCount    = "stargazers_count"
         case watchersCount      = "watchers_count"
         case language

--- a/iOSEngineerCodeCheck/View/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/View/RepositoryDetail/RepositoryDetailViewController.swift
@@ -46,7 +46,7 @@ extension RepositoryDetailViewController {
     
     private func configureLabels() {
         titleLabel.text         = repository.fullName
-        languageLabel.text      = "Written in \(repository.language)"
+        languageLabel.text      = "Written in \(repository.language ?? "")"
         starsLabel.text         = "\(repository.stargazersCount) stars"
         watchersLabel.text      = "\(repository.watchersCount) watchers"
         forksLabel.text         = "\(repository.forksCount) forks"

--- a/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.swift
@@ -39,15 +39,15 @@ class SearchRepositoriesCell: UITableViewCell {
     
     // MARK: Configuration
     
-    func configureCell(title: String, desc: String?, stars: String, language: String?, avatarImage: String?) {
-        titleLabel.text = title
-        descriptionLabel.text = desc
-        starsLabel.text = stars
-        languageLabel.text = language
+    func configureCell(title: String, desc: String?, stars: String, language: String?, avatarURL: String?) {
+        titleLabel.text         = title
+        descriptionLabel.text   = desc
+        starsLabel.text         = stars
+        languageLabel.text      = language
         
-        if let avatarImage = avatarImage,
-           let imageURL = URL(string: avatarImage) {
-            avatarImageView.kf.setImage(with: imageURL, options: [.transition(.fade(0.3))])
+        if let avatarURL    = avatarURL,
+           let url          = URL(string: avatarURL) {
+            avatarImageView.kf.setImage(with: url, options: [.transition(.fade(0.3))])
         } else {
             avatarImageView.image = nil
         }

--- a/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.swift
@@ -1,0 +1,55 @@
+//
+//  SearchRepositoriesCell.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/27.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+import Kingfisher
+
+class SearchRepositoriesCell: UITableViewCell {
+    
+    // MARK: IBOutlet
+    
+    @IBOutlet private weak var avatarImageView: UIImageView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var descriptionLabel: UILabel!
+    @IBOutlet private weak var starsLabel: UILabel!
+    @IBOutlet private weak var languageLabel: UILabel!
+    
+    // MARK: Properties
+    
+    static let reuseIdentifier = "SearchRepositoriesCell"
+    static let rowHeight: CGFloat = 88
+    static var nib: UINib {
+        return UINib(nibName: "SearchRepositoriesCell", bundle: nil)
+    }
+    
+    // MARK: Overrides
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+    
+    // MARK: Configuration
+    
+    func configureCell(title: String, desc: String?, stars: String, language: String?, avatarImage: String?) {
+        titleLabel.text = title
+        descriptionLabel.text = desc
+        starsLabel.text = stars
+        languageLabel.text = language
+        
+        if let avatarImage = avatarImage,
+           let imageURL = URL(string: avatarImage) {
+            avatarImageView.kf.setImage(with: imageURL, options: [.transition(.fade(0.3))])
+        } else {
+            avatarImageView.image = nil
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.xib
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.xib
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="88" id="KGk-i7-Jjw" customClass="SearchRepositoriesCell" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="88"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="293" height="88"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="Htc-Q7-nOI">
+                        <rect key="frame" x="16" y="12" width="261" height="64"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5B5-nA-rBA" customClass="ImageView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="5B5-nA-rBA" secondAttribute="height" multiplier="1:1" id="xVP-oe-aOf"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="32"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" systemColor="opaqueSeparatorColor"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="j9h-5m-zbg">
+                                <rect key="frame" x="77" y="0.0" width="184" height="64"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Vy-ph-5Uh">
+                                        <rect key="frame" x="0.0" y="0.0" width="184" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dSr-yp-tGf">
+                                        <rect key="frame" x="0.0" y="26.5" width="184" height="14.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="izf-zB-sgA">
+                                        <rect key="frame" x="0.0" y="48" width="184" height="16"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="hGp-Wg-uDT">
+                                                <rect key="frame" x="0.0" y="0.0" width="92" height="16"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="UKM-V0-rh0">
+                                                        <rect key="frame" x="0.0" y="-0.5" width="16" height="16"/>
+                                                        <color key="tintColor" systemColor="systemYellowColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="16" id="Piq-eN-8Uq"/>
+                                                            <constraint firstAttribute="height" constant="16" id="lHP-JP-S63"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EZR-oL-omx">
+                                                        <rect key="frame" x="20" y="0.0" width="72" height="16"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="9Z8-aS-NUb">
+                                                <rect key="frame" x="92" y="0.0" width="92" height="16"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pencil" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Rpm-ZL-Hf8">
+                                                        <rect key="frame" x="0.0" y="2.5" width="16" height="11.5"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="16" id="9Yt-G1-bDu"/>
+                                                            <constraint firstAttribute="height" constant="16" id="Rab-gK-eqn"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VXs-8Q-se0">
+                                                        <rect key="frame" x="20" y="0.0" width="72" height="16"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Htc-Q7-nOI" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="Gfc-wO-Kb8"/>
+                    <constraint firstItem="Htc-Q7-nOI" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="TAl-1N-NLT"/>
+                    <constraint firstAttribute="bottom" secondItem="Htc-Q7-nOI" secondAttribute="bottom" constant="12" id="ZBh-Jg-V9T"/>
+                    <constraint firstAttribute="trailing" secondItem="Htc-Q7-nOI" secondAttribute="trailing" constant="16" id="jDx-wv-qam"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="avatarImageView" destination="5B5-nA-rBA" id="Mxg-aA-NRX"/>
+                <outlet property="descriptionLabel" destination="dSr-yp-tGf" id="dG9-1y-Ei7"/>
+                <outlet property="languageLabel" destination="VXs-8Q-se0" id="pgD-8A-hyU"/>
+                <outlet property="starsLabel" destination="EZR-oL-omx" id="yAh-LP-DY3"/>
+                <outlet property="titleLabel" destination="2Vy-ph-5Uh" id="C0T-Sh-UXl"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="82.366071428571431"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="pencil" catalog="system" width="128" height="113"/>
+        <image name="star.fill" catalog="system" width="128" height="116"/>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.xib
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.xib
@@ -21,7 +21,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="Htc-Q7-nOI">
                         <rect key="frame" x="16" y="12" width="261" height="64"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5B5-nA-rBA" customClass="ImageView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5B5-nA-rBA" customClass="ImageView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="5B5-nA-rBA" secondAttribute="height" multiplier="1:1" id="xVP-oe-aOf"/>

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.storyboard
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.storyboard
@@ -20,32 +20,6 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sXS-Sg-TAM">
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Repository" textLabel="QL6-o5-BGB" detailTextLabel="5Qq-1N-Ea1" style="IBUITableViewCellStyleValue1" id="JWT-J1-baM">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JWT-J1-baM" id="MzX-jm-QJk">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QL6-o5-BGB">
-                                                    <rect key="frame" x="20" y="12" width="33" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="5Qq-1N-Ea1">
-                                                    <rect key="frame" x="350" y="12" width="44" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </prototypes>
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="sXZ-tK-R4I"/>

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
@@ -57,7 +57,7 @@ extension SearchRepositoriesViewController {
         
         viewModel.output.repositoriesDriver
             .drive(tableView.rx.items) { tableView, row, element in
-                let cell                    = tableView.dequeueReusableCell(withIdentifier: SearchRepositoriesCell.reuseIdentifier, for: IndexPath(row: row, section: 0)) as! SearchRepositoriesCell
+                let cell = tableView.dequeueReusableCell(withIdentifier: SearchRepositoriesCell.reuseIdentifier, for: IndexPath(row: row, section: 0)) as! SearchRepositoriesCell
                 cell.configureCell(title: element.fullName, desc: element.desc, stars: "\(element.stargazersCount)", language: element.language, avatarURL: element.owner.avatarURL)
                 return cell
             }

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
@@ -58,7 +58,7 @@ extension SearchRepositoriesViewController {
         viewModel.output.repositoriesDriver
             .drive(tableView.rx.items) { tableView, row, element in
                 let cell                    = tableView.dequeueReusableCell(withIdentifier: SearchRepositoriesCell.reuseIdentifier, for: IndexPath(row: row, section: 0)) as! SearchRepositoriesCell
-                cell.configureCell(title: element.name, desc: element.desc, stars: "\(element.stargazersCount)", language: element.language, avatarURL: element.owner.avatarURL)
+                cell.configureCell(title: element.fullName, desc: element.desc, stars: "\(element.stargazersCount)", language: element.language, avatarURL: element.owner.avatarURL)
                 return cell
             }
             .disposed(by: disposeBag)

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
@@ -46,7 +46,9 @@ extension SearchRepositoriesViewController {
     }
     
     private func configureTableView() {
-        tableView.delegate = self
+        tableView.delegate  = self
+        tableView.rowHeight = SearchRepositoriesCell.rowHeight
+        tableView.register(SearchRepositoriesCell.nib, forCellReuseIdentifier: SearchRepositoriesCell.reuseIdentifier)
     }
     
     private func configureViewModel() {
@@ -55,9 +57,8 @@ extension SearchRepositoriesViewController {
         
         viewModel.output.repositoriesDriver
             .drive(tableView.rx.items) { tableView, row, element in
-                let cell                    = tableView.dequeueReusableCell(withIdentifier: "Repository", for: IndexPath(row: row, section: 0))
-                cell.textLabel?.text        = element.fullName
-                cell.detailTextLabel?.text  = element.language
+                let cell                    = tableView.dequeueReusableCell(withIdentifier: SearchRepositoriesCell.reuseIdentifier, for: IndexPath(row: row, section: 0)) as! SearchRepositoriesCell
+                cell.configureCell(title: element.name, desc: element.desc, stars: "\(element.stargazersCount)", language: element.language, avatarURL: element.owner.avatarURL)
                 return cell
             }
             .disposed(by: disposeBag)

--- a/iOSEngineerCodeCheckTests/Common/Util/Stubs.swift
+++ b/iOSEngineerCodeCheckTests/Common/Util/Stubs.swift
@@ -10,8 +10,11 @@ import Foundation
 @testable import iOSEngineerCodeCheck
 
 enum Stubs {
-    static let repository = Repository(fullName: "Stub",
+    static let repository = Repository(name: "Stub",
+                                       fullName: "Stub",
+                                       desc: "Stub",
                                        owner: RepositoryOwner(avatarURL: "Stub"),
+                                       homepage: "Stub",
                                        stargazersCount: 1,
                                        watchersCount: 1,
                                        language: "Stub",
@@ -19,8 +22,11 @@ enum Stubs {
                                        openIssueCount: 1)
     static let searchRepositoriesResponse = SearchRepositoriesResponse(totalCount: 1,
                                                                        items: [
-                                                                        Repository(fullName: "Stub",
+                                                                        Repository(name: "Stub",
+                                                                                   fullName: "Stub",
+                                                                                   desc: "Stub",
                                                                                    owner: RepositoryOwner(avatarURL: "Stub"),
+                                                                                   homepage: "Stub",
                                                                                    stargazersCount: 1,
                                                                                    watchersCount: 1,
                                                                                    language: "Stub",


### PR DESCRIPTION
## 📝 詳細
リポジトリ検索画面のセルを更新。アイコン等は一時的なもの。
表示するデータを増やすためにレスポンスの一部を修正。

## 🏞 プレビュー

| Before | After |
| :-----: | :----: |
| ![Simulator Screen Shot - iPhone 11 - 2020-09-27 at 20 46 35](https://user-images.githubusercontent.com/31949692/94364191-8d78d200-0102-11eb-8d94-2fa1b03ba3d6.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-27 at 20 40 00](https://user-images.githubusercontent.com/31949692/94364178-76d27b00-0102-11eb-8845-f06b84ec814a.png) |