### PR TITLE
🆕 リポジトリ検索画面にページネーションを実装

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		715A62412522A745003AC0E2 /* SearchRepositoriesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A623F2522A745003AC0E2 /* SearchRepositoriesModelTests.swift */; };
 		715A62422522A745003AC0E2 /* StubSearchRepositoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A62402522A745003AC0E2 /* StubSearchRepositoriesModel.swift */; };
 		715A62562522B82E003AC0E2 /* Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A62552522B82E003AC0E2 /* Asset.swift */; };
+		715A625D2522C14E003AC0E2 /* UIScrollView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A625C2522C14E003AC0E2 /* UIScrollView+Rx.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -133,6 +134,7 @@
 		715A623F2522A745003AC0E2 /* SearchRepositoriesModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesModelTests.swift; sourceTree = "<group>"; };
 		715A62402522A745003AC0E2 /* StubSearchRepositoriesModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubSearchRepositoriesModel.swift; sourceTree = "<group>"; };
 		715A62552522B82E003AC0E2 /* Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
+		715A625C2522C14E003AC0E2 /* UIScrollView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Rx.swift"; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -369,6 +371,7 @@
 		71402046251E501D007CE443 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				715A625B2522C141003AC0E2 /* Extension */,
 				71402047251E5025007CE443 /* View */,
 			);
 			path = Common;
@@ -401,6 +404,14 @@
 				715A62552522B82E003AC0E2 /* Asset.swift */,
 			);
 			path = Generated;
+			sourceTree = "<group>";
+		};
+		715A625B2522C141003AC0E2 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				715A625C2522C14E003AC0E2 /* UIScrollView+Rx.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 		BFD945D2244DC5E80012785A = {
@@ -663,6 +674,7 @@
 				715A622D252200D6003AC0E2 /* Button.swift in Sources */,
 				712DAF4A2520AAA200889011 /* SearchRepositoriesCell.swift in Sources */,
 				712D67F6251D9CEE000DC884 /* Repository.swift in Sources */,
+				715A625D2522C14E003AC0E2 /* UIScrollView+Rx.swift in Sources */,
 				715A62562522B82E003AC0E2 /* Asset.swift in Sources */,
 				71402024251E4381007CE443 /* SearchRepositoriesViewModel.swift in Sources */,
 				712D67FE251D9D26000DC884 /* RepositoryOwner.swift in Sources */,

--- a/iOSEngineerCodeCheck/Common/Extension/UIScrollView+Rx.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UIScrollView+Rx.swift
@@ -1,0 +1,31 @@
+//
+//  UIScrollView+Rx.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/29.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+import RxCocoa
+import RxSwift
+
+// https://github.com/tryswift/RxPagination/blob/master/Pagination/UIScrollView%2BRx.swift
+extension Reactive where Base: UIScrollView {
+    var reachedBottom: ControlEvent<Void> {
+        let observable = contentOffset
+            .flatMap { [weak base] contentOffset -> Observable<Void> in
+                guard let scrollView = base else {
+                    return Observable.empty()
+                }
+
+                // NOTE: inset で余白を持たせた分を考慮する.
+                let visibleHeight = scrollView.frame.height - scrollView.contentInset.top - scrollView.contentInset.bottom
+                let y = contentOffset.y + scrollView.contentInset.top
+                let threshold = max(0.0, scrollView.contentSize.height - visibleHeight)
+
+                return y > threshold ? Observable.just(()) : Observable.empty()
+            }
+        return ControlEvent(events: observable)
+    }
+}

--- a/iOSEngineerCodeCheck/Common/Extension/UIScrollView+Rx.swift
+++ b/iOSEngineerCodeCheck/Common/Extension/UIScrollView+Rx.swift
@@ -1,4 +1,4 @@
-//
+//  swiftlint:disable:this file_name
 //  UIScrollView+Rx.swift
 //  iOSEngineerCodeCheck
 //

--- a/iOSEngineerCodeCheck/Model/SearchRepositoriesModel.swift
+++ b/iOSEngineerCodeCheck/Model/SearchRepositoriesModel.swift
@@ -43,7 +43,7 @@ final class SearchRepositoriesModel: SearchRepositoriesModelProtocol {
     // MARK: Call API
 
     func fetchRepositories(with keyword: String) {
-        gitHubAPISearchRepository.searchRepositories(keyword: keyword)
+        gitHubAPISearchRepository.searchRepositories(keyword: keyword, page: 1)
             .subscribe(onSuccess: { [weak self] response in
                 self?.repositoriesRelay.accept(response.items)
             }, onError: { [weak self] error in

--- a/iOSEngineerCodeCheck/Network/Request/SearchRepositoriesRequest.swift
+++ b/iOSEngineerCodeCheck/Network/Request/SearchRepositoriesRequest.swift
@@ -12,6 +12,7 @@ struct SearchRepositoriesRequest: APIRequest {
     typealias Response = SearchRepositoriesResponse
 
     let keyword: String
+    let page: Int
 
     var path: String {
         "/search/repositories"
@@ -27,7 +28,8 @@ struct SearchRepositoriesRequest: APIRequest {
 
     var parameters: Parameters? {
         [
-            "q": keyword
+            "q": keyword,
+            "page": page
         ]
     }
 }

--- a/iOSEngineerCodeCheck/Repository/GitHubAPISearchRepository.swift
+++ b/iOSEngineerCodeCheck/Repository/GitHubAPISearchRepository.swift
@@ -9,7 +9,7 @@
 import RxSwift
 
 protocol GitHubAPISearchRepositoryProtocol {
-    func searchRepositories(keyword: String) -> Single<SearchRepositoriesResponse>
+    func searchRepositories(keyword: String, page: Int) -> Single<SearchRepositoriesResponse>
 }
 
 struct GitHubAPISearchRepository: GitHubAPISearchRepositoryProtocol {
@@ -26,7 +26,7 @@ struct GitHubAPISearchRepository: GitHubAPISearchRepositoryProtocol {
 
     // MARK: Call API
 
-    func searchRepositories(keyword: String) -> Single<SearchRepositoriesResponse> {
-        apiClient.call(with: SearchRepositoriesRequest(keyword: keyword))
+    func searchRepositories(keyword: String, page: Int) -> Single<SearchRepositoriesResponse> {
+        apiClient.call(with: SearchRepositoriesRequest(keyword: keyword, page: page))
     }
 }

--- a/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.xib
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/Cell/SearchRepositoriesCell.xib
@@ -114,6 +114,7 @@
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
             <connections>
                 <outlet property="avatarImageView" destination="5B5-nA-rBA" id="Mxg-aA-NRX"/>
                 <outlet property="descriptionLabel" destination="dSr-yp-tGf" id="dG9-1y-Ei7"/>
@@ -128,6 +129,9 @@
         <image name="ic_star" width="24" height="24"/>
         <systemColor name="opaqueSeparatorColor">
             <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondarySystemGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.storyboard
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.storyboard
@@ -19,7 +19,7 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sXS-Sg-TAM">
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="sXZ-tK-R4I"/>
@@ -62,6 +62,9 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
@@ -55,6 +55,12 @@ extension SearchRepositoriesViewController {
         let viewModel = SearchRepositoriesViewModel()
         self.viewModel = viewModel
 
+        tableView.rx.reachedBottom.asSignal()
+            .emit(onNext: { [weak self] in
+                self?.viewModel.input.didReachBottom()
+            })
+            .disposed(by: disposeBag)
+
         viewModel.output.repositoriesDriver
             .drive(tableView.rx.items) { tableView, row, element in
                 let cell = tableView.dequeueReusableCell(withIdentifier: SearchRepositoriesCell.reuseIdentifier, for: IndexPath(row: row, section: 0)) as! SearchRepositoriesCell // swiftlint:disable:this force_cast

--- a/iOSEngineerCodeCheck/ViewModel/SearchRepositoriesViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModel/SearchRepositoriesViewModel.swift
@@ -12,6 +12,7 @@ import RxCocoa
 protocol SearchRepositoriesViewModelInput {
     func searchBarSearchButtonClicked(keyword: String)
     func didSelectRow(at indexPath: IndexPath)
+    func didReachBottom()
 }
 
 protocol  SearchRepositoriesViewModelOutput {
@@ -57,6 +58,10 @@ final class SearchRepositoriesViewModel: SearchRepositoriesViewModelInput, Searc
 
     func didSelectRow(at indexPath: IndexPath) {
         pushRepositoryDetailRelay.accept(model.repositoriesRelay.value[indexPath.row])
+    }
+
+    func didReachBottom() {
+        model.fetchNextPage()
     }
 }
 

--- a/iOSEngineerCodeCheckTests/Common/Util/Stubs.swift
+++ b/iOSEngineerCodeCheckTests/Common/Util/Stubs.swift
@@ -22,7 +22,7 @@ enum Stubs {
                                        license: RepositoryLicense(key: "Stub", name: "Stub", spdxID: "Stub"),
                                        forksCount: 1,
                                        openIssueCount: 1)
-    static let searchRepositoriesResponse = SearchRepositoriesResponse(totalCount: 1,
+    static let searchRepositoriesResponse = SearchRepositoriesResponse(totalCount: 2,
                                                                        items: [
                                                                         Repository(name: "Stub",
                                                                                    fullName: "Stub",

--- a/iOSEngineerCodeCheckTests/Model/SearchRepositories/StubSearchRepositoriesModel.swift
+++ b/iOSEngineerCodeCheckTests/Model/SearchRepositories/StubSearchRepositoriesModel.swift
@@ -32,4 +32,8 @@ final class StubSearchRepositoriesModel: SearchRepositoriesModelProtocol {
             ? errorRelay.accept(StubError())
             : repositoriesRelay.accept([Stubs.repository])
     }
+    
+    func fetchNextPage() {
+        repositoriesRelay.accept(repositoriesRelay.value + [Stubs.repository])
+    }
 }

--- a/iOSEngineerCodeCheckTests/Repository/StubGitHubAPISearchRepository.swift
+++ b/iOSEngineerCodeCheckTests/Repository/StubGitHubAPISearchRepository.swift
@@ -23,7 +23,7 @@ struct StubGitHubAPISearchRepository: GitHubAPISearchRepositoryProtocol {
     
     // MARK: Call API
     
-    func searchRepositories(keyword: String) -> Single<SearchRepositoriesResponse> {
+    func searchRepositories(keyword: String, page: Int) -> Single<SearchRepositoriesResponse> {
         return isErrorOccurred
             ? Single.error(StubError())
             : Single.just(Stubs.searchRepositoriesResponse)


### PR DESCRIPTION
## 📝 詳細

リポジトリ詳細画面にページネーションの機能を実装。
`TableView` のスクロールが一番下に来たタイミングで次のページを読み込みを行う。

ページネーション実装に伴い **Model** と **ViewModel** 本体を更新。
テストケースも追加。