### PR TITLE
🆕 リポジトリ検索画面に Empty State を表示

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		715A62422522A745003AC0E2 /* StubSearchRepositoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A62402522A745003AC0E2 /* StubSearchRepositoriesModel.swift */; };
 		715A62562522B82E003AC0E2 /* Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A62552522B82E003AC0E2 /* Asset.swift */; };
 		715A625D2522C14E003AC0E2 /* UIScrollView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A625C2522C14E003AC0E2 /* UIScrollView+Rx.swift */; };
+		715A62652522EB10003AC0E2 /* StateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A62642522EB10003AC0E2 /* StateView.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -135,6 +136,7 @@
 		715A62402522A745003AC0E2 /* StubSearchRepositoriesModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubSearchRepositoriesModel.swift; sourceTree = "<group>"; };
 		715A62552522B82E003AC0E2 /* Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
 		715A625C2522C14E003AC0E2 /* UIScrollView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Rx.swift"; sourceTree = "<group>"; };
+		715A62642522EB10003AC0E2 /* StateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateView.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -380,11 +382,12 @@
 		71402047251E5025007CE443 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				715A62242521F69F003AC0E2 /* AlignLeadingButton.swift */,
+				715A622C252200D6003AC0E2 /* Button.swift */,
+				715A62282521F791003AC0E2 /* ContainerView.swift */,
 				71402048251E5035007CE443 /* DisposableViewController.swift */,
 				712DAF432520A96F00889011 /* ImageView.swift */,
-				715A62242521F69F003AC0E2 /* AlignLeadingButton.swift */,
-				715A62282521F791003AC0E2 /* ContainerView.swift */,
-				715A622C252200D6003AC0E2 /* Button.swift */,
+				715A62642522EB10003AC0E2 /* StateView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -672,6 +675,7 @@
 				71402049251E5035007CE443 /* DisposableViewController.swift in Sources */,
 				712DAF442520A96F00889011 /* ImageView.swift in Sources */,
 				715A622D252200D6003AC0E2 /* Button.swift in Sources */,
+				715A62652522EB10003AC0E2 /* StateView.swift in Sources */,
 				712DAF4A2520AAA200889011 /* SearchRepositoriesCell.swift in Sources */,
 				712D67F6251D9CEE000DC884 /* Repository.swift in Sources */,
 				715A625D2522C14E003AC0E2 /* UIScrollView+Rx.swift in Sources */,

--- a/iOSEngineerCodeCheck/Common/View/StateView.swift
+++ b/iOSEngineerCodeCheck/Common/View/StateView.swift
@@ -211,6 +211,20 @@ extension StateView {
 
 extension StateView {
 
+    func updateStyle(emptyImage: UIImage? = nil,
+                     emptyTitle: String? = nil,
+                     emptyContent: String? = nil,
+                     errorImage: UIImage? = nil,
+                     errorTitle: String? = nil,
+                     errorContent: String? = nil) {
+        self.emptyImage = emptyImage
+        self.emptyTitle = emptyTitle
+        self.emptyContent = emptyContent
+        self.errorImage = errorImage
+        self.errorTitle = errorTitle
+        self.errorContent = errorContent
+    }
+
     func setState(of state: State) {
         isHidden = state == .none
         imageView.image = state == .error ? errorImage : emptyImage

--- a/iOSEngineerCodeCheck/Common/View/StateView.swift
+++ b/iOSEngineerCodeCheck/Common/View/StateView.swift
@@ -20,7 +20,7 @@ extension StateViewable {
     func setupStateView() {
         stateView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stateView)
-        
+
         NSLayoutConstraint.activate([
             stateView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -32),
             stateView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
@@ -31,28 +31,28 @@ extension StateViewable {
 
 /// ロード中、エラーの発生などを表示する View.
 class StateView: UIView {
-    
+
     // MARK: Enum
-    
+
     enum State {
         case none
         case loading
         case empty
         case error
     }
-    
+
     // MARK: Properties
-    
+
     private var emptyImage: UIImage?
     private var emptyTitle: String?
     private var emptyContent: String?
-    
+
     private var errorImage: UIImage?
     private var errorTitle: String?
     private var errorContent: String?
-    
+
     // MARK: Views
-    
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.alpha = 0
@@ -64,7 +64,7 @@ class StateView: UIView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
-    
+
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = emptyImage
@@ -73,7 +73,7 @@ class StateView: UIView {
         imageView.heightAnchor.constraint(equalToConstant: 108).isActive = true
         return imageView
     }()
-    
+
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.text = emptyTitle
@@ -83,7 +83,7 @@ class StateView: UIView {
         titleLabel.font = .systemFont(ofSize: 16, weight: .bold)
         return titleLabel
     }()
-    
+
     private lazy var contentLabel: UILabel = {
         let contentLabel = UILabel()
         contentLabel.text = emptyContent
@@ -93,7 +93,7 @@ class StateView: UIView {
         contentLabel.font = .systemFont(ofSize: 14, weight: .regular)
         return contentLabel
     }()
-    
+
     private lazy var indicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView()
         indicator.alpha = 0
@@ -101,14 +101,14 @@ class StateView: UIView {
         indicator.translatesAutoresizingMaskIntoConstraints = false
         return indicator
     }()
-    
+
     // MARK: Lifecycle
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
-    
+
     init(frame: CGRect,
          emptyImage: UIImage? = nil,
          emptyTitle: String? = nil,
@@ -149,7 +149,7 @@ class StateView: UIView {
 // MARK: - Private method
 
 extension StateView {
-    
+
     private func setupViews() {
         // StackView
         addSubview(stackView)
@@ -172,13 +172,13 @@ extension StateView {
             indicator.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
-    
+
     private func animateIndicator(isHidden: Bool) {
         // NOTE: Start activity indicator.
         if !isHidden {
             indicator.startAnimating()
         }
-        
+
         UIView.animate(withDuration: 0.5,
                        delay: 0,
                        options: .curveEaseInOut,
@@ -193,7 +193,7 @@ extension StateView {
                         }
                        })
     }
-    
+
     private func animateStackView(isHidden: Bool) {
         UIView.animate(withDuration: 0.5,
                        delay: 0,
@@ -210,7 +210,7 @@ extension StateView {
 // MARK: - Public method
 
 extension StateView {
-    
+
     func setState(of state: State) {
         isHidden = state == .none
         imageView.image = state == .error ? errorImage : emptyImage

--- a/iOSEngineerCodeCheck/Common/View/StateView.swift
+++ b/iOSEngineerCodeCheck/Common/View/StateView.swift
@@ -1,0 +1,231 @@
+//
+//  StateView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 山田隼也 on 2020/09/29.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+/// `StateView` を表示させる `UIViewController` に適合させる Protocol.
+protocol StateViewable where Self: UIViewController {
+    /// `StateView` を保持.
+    var stateView: StateView { get }
+    /// `StateView` を制約付きで `addSubView()` する.
+    func setupStateView()
+}
+
+extension StateViewable {
+    func setupStateView() {
+        stateView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stateView)
+        
+        NSLayoutConstraint.activate([
+            stateView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -32),
+            stateView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
+            stateView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32)
+        ])
+    }
+}
+
+/// ロード中、エラーの発生などを表示する View.
+class StateView: UIView {
+    
+    // MARK: Enum
+    
+    enum State {
+        case none
+        case loading
+        case empty
+        case error
+    }
+    
+    // MARK: Properties
+    
+    private var emptyImage: UIImage?
+    private var emptyTitle: String?
+    private var emptyContent: String?
+    
+    private var errorImage: UIImage?
+    private var errorTitle: String?
+    private var errorContent: String?
+    
+    // MARK: Views
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alpha = 0
+        stackView.spacing = 4
+        stackView.isHidden = true
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .equalSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = emptyImage
+        imageView.tintColor = .lightGray
+        imageView.contentMode = .scaleAspectFit
+        imageView.heightAnchor.constraint(equalToConstant: 108).isActive = true
+        return imageView
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let titleLabel = UILabel()
+        titleLabel.text = emptyTitle
+        titleLabel.numberOfLines = 1
+        titleLabel.textColor = .lightGray
+        titleLabel.textAlignment = .center
+        titleLabel.font = .systemFont(ofSize: 16, weight: .bold)
+        return titleLabel
+    }()
+    
+    private lazy var contentLabel: UILabel = {
+        let contentLabel = UILabel()
+        contentLabel.text = emptyContent
+        contentLabel.numberOfLines = 0
+        contentLabel.textColor = .lightGray
+        contentLabel.textAlignment = .center
+        contentLabel.font = .systemFont(ofSize: 14, weight: .regular)
+        return contentLabel
+    }()
+    
+    private lazy var indicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView()
+        indicator.alpha = 0
+        indicator.isHidden = true
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+    
+    // MARK: Lifecycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    init(frame: CGRect,
+         emptyImage: UIImage? = nil,
+         emptyTitle: String? = nil,
+         emptyContent: String? = nil,
+         errorImage: UIImage? = nil,
+         errorTitle: String? = nil,
+         errorContent: String? = nil) {
+        super.init(frame: frame)
+        self.emptyImage = emptyImage
+        self.emptyTitle = emptyTitle
+        self.emptyContent = emptyContent
+        self.errorImage = errorImage
+        self.errorTitle = errorTitle
+        self.errorContent = errorContent
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        commonInit()
+    }
+
+    override func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        commonInit()
+    }
+
+    private func commonInit() {
+        isExclusiveTouch = true
+        setupViews()
+    }
+}
+
+// MARK: - Private method
+
+extension StateView {
+    
+    private func setupViews() {
+        // StackView
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        // ImageView
+        stackView.addArrangedSubview(imageView)
+        // TitleLabel
+        stackView.addArrangedSubview(titleLabel)
+        // ContentLabel
+        stackView.addArrangedSubview(contentLabel)
+        // Indicator
+        addSubview(indicator)
+        NSLayoutConstraint.activate([
+            indicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+    
+    private func animateIndicator(isHidden: Bool) {
+        // NOTE: Start activity indicator.
+        if !isHidden {
+            indicator.startAnimating()
+        }
+        
+        UIView.animate(withDuration: 0.5,
+                       delay: 0,
+                       options: .curveEaseInOut,
+                       animations: {
+                        self.indicator.alpha = isHidden ? 0 : 1
+                       },
+                       completion: { _ in
+                        self.indicator.isHidden = isHidden
+                        // NOTE: Stop activity indicator animation when finish animation.
+                        if isHidden {
+                            self.indicator.stopAnimating()
+                        }
+                       })
+    }
+    
+    private func animateStackView(isHidden: Bool) {
+        UIView.animate(withDuration: 0.5,
+                       delay: 0,
+                       options: .curveEaseInOut,
+                       animations: {
+                        self.stackView.alpha = isHidden ? 0 : 1
+                       },
+                       completion: { _ in
+                        self.stackView.isHidden = isHidden
+                       })
+    }
+}
+
+// MARK: - Public method
+
+extension StateView {
+    
+    func setState(of state: State) {
+        isHidden = state == .none
+        imageView.image = state == .error ? errorImage : emptyImage
+        titleLabel.text = state == .error ? errorTitle : emptyTitle
+        contentLabel.text = state == .error ? errorContent : emptyContent
+        switch state {
+        case .none:
+            animateIndicator(isHidden: true)
+            animateStackView(isHidden: true)
+        case .loading:
+            animateIndicator(isHidden: false)
+            animateStackView(isHidden: true)
+        case .empty, .error:
+            animateIndicator(isHidden: true)
+            animateStackView(isHidden: false)
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/Model/SearchRepositoriesModel.swift
+++ b/iOSEngineerCodeCheck/Model/SearchRepositoriesModel.swift
@@ -66,6 +66,7 @@ final class SearchRepositoriesModel: SearchRepositoriesModelProtocol {
                 self.isLoadingRelay.accept(false)
                 self.repositoriesRelay.accept(response.items)
             }, onError: { [weak self] error in
+                self?.isLoadingRelay.accept(false)
                 self?.errorRelay.accept(error)
             })
             .disposed(by: disposeBag)

--- a/iOSEngineerCodeCheck/View/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/View/RepositoryDetail/RepositoryDetailViewController.swift
@@ -91,10 +91,10 @@ extension RepositoryDetailViewController {
         descriptionLabel.text = repository.desc
         languageLabel.text = repository.language
         languageLabel.superview?.isHidden = repository.language == nil
-        starsLabel.text                     = "\(repository.stargazersCount)"
-        watchersLabel.text                  = "\(repository.watchersCount)"
-        forksLabel.text                     = "\(repository.forksCount)"
-        openIssuesLabel.text                = "\(repository.openIssueCount)"
+        starsLabel.text = "\(repository.stargazersCount)"
+        watchersLabel.text = "\(repository.watchersCount)"
+        forksLabel.text = "\(repository.forksCount)"
+        openIssuesLabel.text = "\(repository.openIssueCount)"
     }
 
     private func bindButtons(with repository: Repository) {

--- a/iOSEngineerCodeCheck/View/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/View/RepositoryDetail/RepositoryDetailViewController.swift
@@ -80,7 +80,7 @@ extension RepositoryDetailViewController {
     }
 }
 
-// MARK: - Bind ViewModel
+// MARK: - Binding
 
 extension RepositoryDetailViewController {
 

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.storyboard
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.storyboard
@@ -23,7 +23,7 @@
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="sXZ-tK-R4I"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="sXS-Sg-TAM" firstAttribute="top" secondItem="sXZ-tK-R4I" secondAttribute="top" id="1gS-gd-9qu"/>
                             <constraint firstAttribute="bottom" secondItem="sXS-Sg-TAM" secondAttribute="bottom" id="DLZ-oD-egx"/>
@@ -60,9 +60,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
@@ -40,7 +40,7 @@ extension SearchRepositoriesViewController {
     private func configureNavigation() {
         let searchBar = UISearchBar(frame: navigationController?.navigationBar.frame ?? .zero)
         searchBar.delegate = self
-        searchBar.placeholder           = "リポジトリを検索"
+        searchBar.placeholder = "リポジトリを検索"
         navigationItem.titleView = searchBar
         navigationItem.titleView?.frame = searchBar.frame
     }

--- a/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositories/SearchRepositoriesViewController.swift
@@ -51,12 +51,12 @@ extension SearchRepositoriesViewController {
     func configureStateView() {
         setupStateView()
         stateView.updateStyle(emptyTitle: "検索結果がありません。", emptyContent: "キーワードを入力して検索してください。", errorTitle: "予期しないエラーが発生しました。")
-        stateView.setState(of: .empty)
     }
 
     private func configureTableView() {
         tableView.alpha = 0
         tableView.delegate = self
+        tableView.tableFooterView = UIView()
         tableView.rowHeight = SearchRepositoriesCell.rowHeight
         tableView.register(SearchRepositoriesCell.nib, forCellReuseIdentifier: SearchRepositoriesCell.reuseIdentifier)
     }

--- a/iOSEngineerCodeCheck/ViewModel/RepositoryDetailViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModel/RepositoryDetailViewModel.swift
@@ -48,7 +48,8 @@ final class RepositoryDetailViewModel: RepositoryDetailViewModelInput, Repositor
     // MARK: Trigger
 
     func tappedLinkButton(url: String) {
-        guard let url = URL(string: url) else {
+        guard url.hasPrefix("http"),
+              let url = URL(string: url) else {
             return
         }
         urlRelay.accept(url)

--- a/iOSEngineerCodeCheckTests/Model/SearchRepositories/SearchRepositoriesModelTests.swift
+++ b/iOSEngineerCodeCheckTests/Model/SearchRepositories/SearchRepositoriesModelTests.swift
@@ -66,6 +66,31 @@ class SearchRepositoriesModelTests: XCTestCase {
         XCTAssertEqual(testableObserver.events, expression)
     }
     
+    func test_初回データ取得時にロード中を表すフラグが正しく流れることを確認() {
+        let model               = SearchRepositoriesModel(gitHubAPISearchRepository: StubGitHubAPISearchRepository())
+        let disposeBag          = DisposeBag()
+        let scheduler           = TestScheduler(initialClock: 0)
+        let testableObserver    = scheduler.createObserver(Bool.self)
+        
+        scheduler.scheduleAt(100) {
+            model.isLoadingRelay
+                .subscribe(testableObserver)
+                .disposed(by: disposeBag)
+        }
+        
+        scheduler.scheduleAt(200) {
+            model.fetchRepositories(with: "TEST")
+        }
+        
+        scheduler.start()
+        
+        let expression = Recorded.events([
+            .next(200, true),
+            .next(200, false)
+        ])
+        XCTAssertEqual(testableObserver.events, expression)
+    }
+    
     func test_初回データ取得後の次のページを取得した場合にデータが正しく流れることを確認() {
         let model               = SearchRepositoriesModel(gitHubAPISearchRepository: StubGitHubAPISearchRepository())
         let disposeBag          = DisposeBag()

--- a/iOSEngineerCodeCheckTests/Model/SearchRepositories/StubSearchRepositoriesModel.swift
+++ b/iOSEngineerCodeCheckTests/Model/SearchRepositories/StubSearchRepositoriesModel.swift
@@ -19,21 +19,23 @@ final class StubSearchRepositoriesModel: SearchRepositoriesModelProtocol {
     var errorRelay = PublishRelay<Error>()
     
     private let isErrorOccured: Bool
+    private let isRepositoriesEmpty: Bool
     
     // MARK: Initializer
     
-    init(isErrorOccured: Bool = false) {
+    init(isErrorOccured: Bool = false, isRepositoriesEmpty: Bool = false) {
         self.isErrorOccured = isErrorOccured
+        self.isRepositoriesEmpty = isRepositoriesEmpty
     }
     
     // MARK: Call API
     
     func fetchRepositories(with keyword: String) {
         isLoadingRelay.accept(true)
+        isLoadingRelay.accept(false)
         isErrorOccured
             ? errorRelay.accept(StubError())
-            : repositoriesRelay.accept([Stubs.repository])
-        isLoadingRelay.accept(false)
+            : repositoriesRelay.accept(isRepositoriesEmpty ? [] : [Stubs.repository])
     }
     
     func fetchNextPage() {

--- a/iOSEngineerCodeCheckTests/Model/SearchRepositories/StubSearchRepositoriesModel.swift
+++ b/iOSEngineerCodeCheckTests/Model/SearchRepositories/StubSearchRepositoriesModel.swift
@@ -14,6 +14,7 @@ final class StubSearchRepositoriesModel: SearchRepositoriesModelProtocol {
     
     // MARK: Properties
     
+    var isLoadingRelay = PublishRelay<Bool>()
     var repositoriesRelay = BehaviorRelay<[Repository]>(value: [])
     var errorRelay = PublishRelay<Error>()
     
@@ -28,9 +29,11 @@ final class StubSearchRepositoriesModel: SearchRepositoriesModelProtocol {
     // MARK: Call API
     
     func fetchRepositories(with keyword: String) {
+        isLoadingRelay.accept(true)
         isErrorOccured
             ? errorRelay.accept(StubError())
             : repositoriesRelay.accept([Stubs.repository])
+        isLoadingRelay.accept(false)
     }
     
     func fetchNextPage() {

--- a/iOSEngineerCodeCheckTests/ViewModel/SearchRepositoriesViewModelTests.swift
+++ b/iOSEngineerCodeCheckTests/ViewModel/SearchRepositoriesViewModelTests.swift
@@ -138,4 +138,84 @@ class SearchRepositoriesViewModelTests: XCTestCase {
         ])
         XCTAssertEqual(testableObserver.events, expression)
     }
+    
+    func test_検索実行から完了までのStateの値が正しいことを確認() {
+        let viewModel           = SearchRepositoriesViewModel(model: StubSearchRepositoriesModel())
+        let disposeBag          = DisposeBag()
+        let scheduler           = TestScheduler(initialClock: 0)
+        let testableObserver    = scheduler.createObserver(StateView.State.self)
+        
+        scheduler.scheduleAt(100) {
+            viewModel.output.stateDriver
+                .drive(testableObserver)
+                .disposed(by: disposeBag)
+        }
+
+        scheduler.scheduleAt(200) {
+            viewModel.input.searchBarSearchButtonClicked(keyword: "TEST")
+        }
+        
+        scheduler.start()
+        
+        let expression = Recorded.events([
+            .next(100, StateView.State.empty),
+            .next(200, StateView.State.loading),
+            .next(200, StateView.State.none)
+        ])
+        XCTAssertEqual(testableObserver.events, expression)
+    }
+    
+    func test_検索結果が何もなかった場合のStateの値が正しいことを確認() {
+        let viewModel           = SearchRepositoriesViewModel(model: StubSearchRepositoriesModel(isRepositoriesEmpty: true))
+        let disposeBag          = DisposeBag()
+        let scheduler           = TestScheduler(initialClock: 0)
+        let testableObserver    = scheduler.createObserver(StateView.State.self)
+        
+        scheduler.scheduleAt(100) {
+            viewModel.output.stateDriver
+                .drive(testableObserver)
+                .disposed(by: disposeBag)
+        }
+
+        scheduler.scheduleAt(200) {
+            viewModel.input.searchBarSearchButtonClicked(keyword: "TEST")
+        }
+        
+        scheduler.start()
+        
+        let expression = Recorded.events([
+            .next(100, StateView.State.empty),
+            .next(200, StateView.State.loading),
+            .next(200, StateView.State.none),
+            .next(200, StateView.State.empty)
+        ])
+        XCTAssertEqual(testableObserver.events, expression)
+    }
+    
+    func test_検索実行時にエラーが発生した場合のStateの値が正しいことを確認() {
+        let viewModel           = SearchRepositoriesViewModel(model: StubSearchRepositoriesModel(isErrorOccured: true))
+        let disposeBag          = DisposeBag()
+        let scheduler           = TestScheduler(initialClock: 0)
+        let testableObserver    = scheduler.createObserver(StateView.State.self)
+        
+        scheduler.scheduleAt(100) {
+            viewModel.output.stateDriver
+                .drive(testableObserver)
+                .disposed(by: disposeBag)
+        }
+
+        scheduler.scheduleAt(200) {
+            viewModel.input.searchBarSearchButtonClicked(keyword: "TEST")
+        }
+        
+        scheduler.start()
+        
+        let expression = Recorded.events([
+            .next(100, StateView.State.empty),
+            .next(200, StateView.State.loading),
+            .next(200, StateView.State.none),
+            .next(200, StateView.State.error)
+        ])
+        XCTAssertEqual(testableObserver.events, expression)
+    }
 }


### PR DESCRIPTION
## 📝 詳細

検索前、検索中、エラー時にそれぞれ現在の状態を表す `StateView` を追加。
**Model** の実行結果によって **ViewModel** から `StateView.State` を流す `Driver` を追加。
それに伴い **ViewModel** のテストケースを追加。

### リポジトリ詳細画面でクラッシュする問題を修正

リポジトリの `homepage` には `http` から始まるものが入っているわけではないため、
`swift.org` のような文字列が入っていた場合、`SFSafariViewController` で遷移する際にクラッシュしていた。
なので `http` をプレフィックスとして持つか確認する処理を追加して対応。